### PR TITLE
Bossbar visible method require arg of incorrect type

### DIFF
--- a/src/commands/implementations/Bossbar.ts
+++ b/src/commands/implementations/Bossbar.ts
@@ -113,5 +113,5 @@ class BossbarSet extends Command {
    * @param visible Whether the bossbar is visible or not.
    */
   @command('visible', { isRoot: false })
-    visible = (visible: number) => { }
+    visible = (visible: boolean) => { }
 }


### PR DESCRIPTION
visible method of bossbar takes the argument of type `number`, but it should take argument of type` boolean`.
I have changed the type from `number` to `boolean`.
```bossbar.set('timer_lvl_4').visible(true);``` : correct function
```bossbar.set('timer_lvl_4').visible(1);``` : incorrect function

modified:   src/commands/implementations/Bossbar.ts