### PR TITLE
Fixed the worldborder.center command.

### DIFF
--- a/src/commands/implementations/WorldBorder.ts
+++ b/src/commands/implementations/WorldBorder.ts
@@ -1,7 +1,7 @@
 import { Command } from '@commands/Command'
 import { command } from '@commands/decorators'
 
-import type { Coordinates } from '@arguments'
+import type { ColumnCoordinates, Coordinates } from '@arguments'
 
 /** These commands control the world border. */
 export class WorldBorder extends Command {
@@ -22,7 +22,7 @@ export class WorldBorder extends Command {
      * @param pos Specifies the horizontal coordinates of the world border's center.
      */
     @command(['worldborder', 'center'], { isRoot: true })
-      center = (pos: Coordinates) => {}
+      center = (pos: ColumnCoordinates) => {}
 
     /**
      * Sets the world border damage amount to the specified value.


### PR DESCRIPTION
It now accepts vec2 coordinate instead of vec3.

Incoreect: 
![image](https://user-images.githubusercontent.com/67660416/216120902-ea0c137f-1559-4619-96ce-2ddfa041689a.png)

Correct:
![image](https://user-images.githubusercontent.com/67660416/216120995-1e3e8099-0b5a-4bf2-a718-fbe9f7ffafa6.png)
