### PR TITLE
Fix worldborder.center.

### DIFF
--- a/src/commands/implementations/worldborder.ts
+++ b/src/commands/implementations/worldborder.ts
@@ -3,7 +3,7 @@ import { coordinatesParser } from '#variables'
 
 import { CommandArguments } from '../helpers'
 
-import type { Coordinates } from '#arguments'
+import type { ColumnCoordinates } from '#arguments'
 
 export class WorldBorderNode extends CommandNode {
   command = 'worldborder' as const
@@ -28,7 +28,7 @@ export class WorldBorderCommand extends CommandArguments {
    *
    * @param pos Specifies the horizontal coordinates of the world border's center.
    */
-  center = (pos: Coordinates) => this.finalCommand(['center', coordinatesParser(pos)])
+  center = (pos: ColumnCoordinates) => this.finalCommand(['center', coordinatesParser(pos)])
 
   damage = {
     /**


### PR DESCRIPTION
It now accepts vec2 coordinate instead of vec3.

Incoreect:
![216120902-ea0c137f-1559-4619-96ce-2ddfa041689a](https://user-images.githubusercontent.com/67660416/216333755-1cac84d4-2d22-43a6-982e-8ef2c2d88b56.png)

Correct:
![216120995-1e3e8099-0b5a-4bf2-a718-fbe9f7ffafa6](https://user-images.githubusercontent.com/67660416/216333784-b8c3b233-57a4-48b8-b68e-08d5d6e92d02.png)

With updated repo
