### PR TITLE
Fixed worldborder.center command

### DIFF
--- a/src/commands/implementations/worldborder.ts
+++ b/src/commands/implementations/worldborder.ts
@@ -3,7 +3,7 @@ import { coordinatesParser } from '#variables'
 
 import { CommandArguments } from '../helpers'
 
-import type { Coordinates } from '#arguments'
+import type { ColumnCoordinates } from '#arguments'
 
 export class WorldBorderNode extends CommandNode {
   command = 'worldborder' as const
@@ -28,7 +28,7 @@ export class WorldBorderCommand extends CommandArguments {
    *
    * @param pos Specifies the horizontal coordinates of the world border's center.
    */
-  center = (pos: Coordinates) => this.finalCommand(['center', coordinatesParser(pos)])
+  center = (pos: ColumnCoordinates) => this.finalCommand(['center', coordinatesParser(pos)])
 
   damage = {
     /**


### PR DESCRIPTION
It now accepts vec2 coordinate instead of vec3.

Incorrect:
![216333755-1cac84d4-2d22-43a6-982e-8ef2c2d88b56](https://user-images.githubusercontent.com/67660416/216336409-97772c6b-9e40-456d-b092-69da4ea9a1e3.png)

Correct:
![216333784-b8c3b233-57a4-48b8-b68e-08d5d6e92d02](https://user-images.githubusercontent.com/67660416/216336479-3840959e-0804-4a03-9ed2-f6c8480bcc7f.png)
