### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/src/arguments/resources/datapack/structure.ts
+++ b/src/arguments/resources/datapack/structure.ts
@@ -4,7 +4,7 @@ import type { BLOCKS, RootNBT } from '../../index'
 type Vec3 = [number, number, number]
 
 export type StructureNBT = {
-  /** [Data version](https://minecraft.fandom.com/wiki/Data_version). A positive integer. */
+  /** [Data version](https://minecraft.wiki/w/Data_version). A positive integer. */
   DataVersion?: number
 
   /** A list of positive integers. */

--- a/src/commands/implementations/block/place.ts
+++ b/src/commands/implementations/block/place.ts
@@ -41,7 +41,7 @@ export class PlaceCommand extends CommandArguments {
   jigsaw = (pool: LiteralUnion<WORLDGEN_TEMPLATE_POOLS>, target: string, maxDepth: number, pos: Coordinates = '~ ~ ~') => this.finalCommand(['jigsaw', pool, target, `${validateIntegerRange(maxDepth, 'Jigsaw max depth', 0, 7)}`, coordinatesParser(pos)])
 
   /**
-   * Places a configured structure feature. (not from `data/<namespace>/structures`, see [the wiki](https://minecraft.fandom.com/wiki/Custom_structure#Configured_Structure_Feature))
+   * Places a configured structure feature. (not from `data/<namespace>/structures`, see [the wiki](https://minecraft.wiki/w/Custom_structure#Configured_Structure_Feature))
    *
    * @param configuredStructure The configured structure feature to place.
    * @param pos Optional. Where to place.

--- a/src/core/resources/resourcepack/model.ts
+++ b/src/core/resources/resourcepack/model.ts
@@ -30,7 +30,7 @@ type ElementFace = {
 export const MAX_CUSTOM_MODEL_DATA = 16777216
 
 /**
- * @see https://minecraft.fandom.com/wiki/Model
+ * @see https://minecraft.wiki/w/Model
  */
 export type ModelData = {
   parent?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export type ResourcePackConfig = {
    * The format version of the resource pack.
    * Can change depending on the versions of Minecraft.
    *
-   * @see [https://minecraft.fandom.com/wiki/Resource_pack#Contents](https://minecraft.fandom.com/wiki/Resource_pack#Contents)
+   * @see [https://minecraft.wiki/w/Resource_pack#Contents](https://minecraft.wiki/w/Resource_pack#Contents)
    */
   packFormat: number
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki