### PR TITLE
Performance improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
 on:
+  push:
+    branches-ignore: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/src/arguments/resources/datapack/tag.ts
+++ b/src/arguments/resources/datapack/tag.ts
@@ -15,31 +15,22 @@ import type {
 import type { MCFunctionClass, TagClass } from 'sandstone/core'
 import type { LiteralUnion } from 'sandstone/utils'
 
-export type HintedTagStringType<T extends LiteralUnion<REGISTRIES>> = T extends 'blocks'
-  ? LiteralUnion<BLOCKS>
-  : T extends 'fluids'
-    ? LiteralUnion<FLUIDS>
-    : T extends 'entity_types'
-      ? LiteralUnion<ENTITY_TYPES>
-      : T extends 'functions'
-        ? LiteralUnion<string> | MCFunctionClass<undefined, undefined>
-        : T extends 'items'
-          ? LiteralUnion<ITEMS>
-          : T extends 'dimensions'
-            ? LiteralUnion<DIMENSIONS>
-            : T extends 'game_events'
-              ? LiteralUnion<GAME_EVENTS>
-              : T extends 'cat_variant'
-                ? LiteralUnion<CAT_VARIANTS>
-                : T extends 'painting_variant'
-                  ? LiteralUnion<PAINTING_VARIANTS>
-                  : T extends 'point_of_interest_type'
-                    ? LiteralUnion<POINT_OF_INTEREST_TYPES>
-                    : T extends 'banner_pattern'
-                      ? LiteralUnion<BANNER_PATTERNS>
-                      : T extends 'worldgen/biome'
-                        ? LiteralUnion<WORLDGEN_BIOMES>
-                        : string
+/** biome-ignore format: excessive formatting */
+export type HintedTagStringType<T extends LiteralUnion<REGISTRIES>> = (
+  T extends 'blocks' ? LiteralUnion<BLOCKS> :
+  T extends 'fluids' ? LiteralUnion<FLUIDS> :
+  T extends 'entity_types' ? LiteralUnion<ENTITY_TYPES> :
+  T extends 'functions' ? (LiteralUnion<string> | MCFunctionClass<undefined, undefined>) :
+  T extends 'items' ? LiteralUnion<ITEMS> :
+  T extends 'dimensions' ? LiteralUnion<DIMENSIONS> :
+  T extends 'game_events' ? LiteralUnion<GAME_EVENTS> :
+  T extends 'cat_variant' ? LiteralUnion<CAT_VARIANTS> :
+  T extends 'painting_variant' ? LiteralUnion<PAINTING_VARIANTS> :
+  T extends 'point_of_interest_type' ? LiteralUnion<POINT_OF_INTEREST_TYPES> :
+  T extends 'banner_pattern' ? LiteralUnion<BANNER_PATTERNS> :
+  T extends 'worldgen/biome' ? LiteralUnion<WORLDGEN_BIOMES> :
+  string
+)
 
 export type TagSingleValue<T> = T | { id: T; required: boolean }
 

--- a/src/commands/implementations/block/place.ts
+++ b/src/commands/implementations/block/place.ts
@@ -19,6 +19,8 @@ export class PlaceCommandNode extends CommandNode {
 
 export class PlaceCommand<MACRO extends boolean> extends CommandArguments {
   protected NodeType = PlaceCommandNode
+
+  // TODO: When working on worldgen add Feature Class here
   /**
    * Attempts to place a worldgen feature.
    *

--- a/src/commands/implementations/entity/execute.ts
+++ b/src/commands/implementations/entity/execute.ts
@@ -161,18 +161,11 @@ export class ExecuteCommandNode extends ContainerCommandNode<SubCommand[]> {
       return { node: this as ExecuteCommandNode }
     }
 
-    const namespace = currentMCFunction.resource.name.includes(':')
-      ? `${currentMCFunction.resource.name.split(':')[0]}:`
-      : ''
-
     // Create a new MCFunctionNode with the body of the ExecuteNode.
-    const mcFunction = this.sandstonePack.MCFunction(
-      `${namespace}${currentMCFunction.resource.path.slice(2).join('/')}/${this.callbackName}`,
-      {
-        creator: 'sandstone',
-        onConflict: 'rename',
-      },
-    )
+    const mcFunction = this.sandstonePack.MCFunction(`${currentMCFunction.resource.name}/${this.callbackName}`, {
+      creator: 'sandstone',
+      onConflict: 'rename',
+    })
     const mcFunctionNode = mcFunction.node
     mcFunctionNode.body = this.body
 

--- a/src/core/sandstoneCore.ts
+++ b/src/core/sandstoneCore.ts
@@ -9,13 +9,13 @@ import { MCMetaCache } from './mcmeta.js'
 import type { AwaitNode } from './nodes.js'
 import type { _RawMCFunctionClass, MCFunctionClass, MCFunctionNode } from './resources/datapack/mcfunction.js'
 import { SmithedDependencyClass } from './resources/dependency.js'
-import type { ResourceClass, ResourceNode } from './resources/resource.js'
+import { type ResourceClass, ResourceNode, ResourceNodesMap } from './resources/resource.js'
 import { SmithedDependencyCache } from './smithed.js'
 import type { GenericCoreVisitor } from './visitors.js'
 
 export class SandstoneCore {
   /** All Resources */
-  resourceNodes: Set<ResourceNode>
+  resourceNodes: ResourceNodesMap
 
   mcfunctionStack: MCFunctionNode[]
 
@@ -30,7 +30,7 @@ export class SandstoneCore {
   dependencies: Promise<SmithedDependencyClass[] | true>[] = []
 
   constructor(public pack: SandstonePack) {
-    this.resourceNodes = new Set()
+    this.resourceNodes = new ResourceNodesMap()
     this.mcfunctionStack = []
     this.awaitNodes = new Set()
 
@@ -202,7 +202,7 @@ export class SandstoneCore {
   }
 
   generateResources = (opts: { visitors: GenericCoreVisitor[] }) => {
-    const originalResources = new Set(this.resourceNodes)
+    const originalResources = new ResourceNodesMap(this.resourceNodes)
 
     // First, generate all the resources.
     for (const { resource } of this.resourceNodes) {

--- a/src/pack/visitors/containerCommandsToMCFunction.ts
+++ b/src/pack/visitors/containerCommandsToMCFunction.ts
@@ -15,20 +15,16 @@ export class ContainerCommandsToMCFunctionVisitor extends GenericSandstoneVisito
   currentMCFunction: MCFunctionNode | null = null
 
   visitContainerCommandNode = (node_: ContainerCommandNode) => {
-    // console.log('bippity', bippity++)
     const { node, mcFunction } = node_.createMCFunction(this.currentMCFunction)
 
     if (mcFunction) {
       const visitedMCFunction = this.visitMCFunctionNode(mcFunction)
       this.core.resourceNodes.add(visitedMCFunction)
     } else if (node instanceof ContainerCommandNode && node.body) {
-      for (const [i, child] of node.body.entries()) {
-        const visit = this.genericVisit(child)
-        node.body.splice(i, 1, ...(Array.isArray(visit) ? visit : [visit]))
-      }
+      this.genericVisit(node)
     }
 
-    return Array.isArray(node) ? node.flatMap((n) => this.genericVisit(n)) : node
+    return Array.isArray(node) ? node.flatMap((n) => this.visit(n)) : node
   }
 
   visitMCFunctionNode = (node: MCFunctionNode) => {

--- a/src/variables/parsers.ts
+++ b/src/variables/parsers.ts
@@ -76,21 +76,15 @@ export const structureRotationParser = (rotation?: StructureRotation | MacroArgu
   }
 
   const numToLiteral = (angle: number): STRUCTURE_ROTATION => {
+    /** biome-ignore format: excessive formatting */
     switch (angle) {
-      case 0:
-        return 'none'
-      case 90:
-        return 'clockwise_90'
-      case 180:
-        return '180'
-      case 270:
-        return 'counterclockwise_90'
-      case -90:
-        return 'counterclockwise_90'
-      case -180:
-        return '180'
-      case -270:
-        return 'clockwise_90'
+      case 0: return 'none'
+      case 90: return 'clockwise_90'
+      case 180: return '180'
+      case 270: return 'counterclockwise_90'
+      case -90: return 'counterclockwise_90'
+      case -180: return '180'
+      case -270: return 'clockwise_90'
       default: {
         if (!Number.isInteger(angle / 90)) {
           throw new Error('Structure rotation must be in increments of 90!')

--- a/tests/text/flow/if.test.ts
+++ b/tests/text/flow/if.test.ts
@@ -1,6 +1,6 @@
 import { _, Data, execute, MCFunction, Objective, say } from 'sandstone'
-import { describe, it } from 'vitest'
-import { compareOutputText } from '../../utils'
+import { describe, expect, it } from 'vitest'
+import { compareOutputText, getGeneratedFunctionsText } from '../../utils'
 
 describe('If/Else tests', () => {
   const objective = Objective.get('test')
@@ -179,4 +179,44 @@ describe('If/Else tests', () => {
       },
     )
   })
+
+  it('Should be fast to compile iteratively', async () => {
+    getGeneratedFunctionsText(() => {
+      MCFunction(
+        'default:test',
+        () => {
+          for (let i = 0; i < 1_000; i++) {
+            _.if(_.block('~ ~ ~', 'acacia_button'), () => {
+              say('wow!')
+            })
+          }
+        },
+        {
+          onConflict: 'replace',
+        },
+      )
+    })
+  }, 2_000) // Should compile in less than 2s
+
+  it('Should be fast to compile recursively', async () => {
+    function createIf(i: number): void {
+      if (i >= 1_000) return
+      _.if(_.block('~ ~ ~', 'acacia_button'), () => {
+        say('wow!')
+        createIf(i + 1)
+      })
+    }
+
+    getGeneratedFunctionsText(() => {
+      MCFunction(
+        'default:test',
+        () => {
+          createIf(0)
+        },
+        {
+          onConflict: 'replace',
+        },
+      )
+    })
+  }, 2_000) // Should compile in less than 2 seconds
 })

--- a/tests/text/flow/if.test.ts
+++ b/tests/text/flow/if.test.ts
@@ -200,7 +200,7 @@ describe('If/Else tests', () => {
 
   it('Should be fast to compile recursively', async () => {
     function createIf(i: number): void {
-      if (i >= 1_000) return
+      if (i >= 500) return
       _.if(_.block('~ ~ ~', 'acacia_button'), () => {
         say('wow!')
         createIf(i + 1)


### PR DESCRIPTION
## Why?

Using a high number of recursive `If` was slowing down the compilation.

Profiling showed the bottleneck was `handleConflict`, a `O(N)` operation that happens everytime we add a new Node.

## The fix

I switched the `resourceNodes` `Set` to a "custom" `Map` class, `ResourceNodesMap`. This automatically manages the Map keys by concatenating the packType and the path components.

## Performance improvements

### Before

* Generating 1500 nested `if` took `33.430s`
* Generating 100k sequential `if` took `17.02s`

### After

* Generating 5000 nested `if` now takes `0.889s` (x37 🚀)
* Generating 100k sequential `if` now takes `2.254s` (x7.5 🚀 )

More generally, the new O(1) complexity means Sandstone will better scale on large projects.