### PR TITLE
Update CI: actions/checkout v3→v4, actions/setup-node v3→v4, node 16→20

### DIFF
--- a/.github/workflows/mc-update.yml
+++ b/.github/workflows/mc-update.yml
@@ -14,10 +14,10 @@ jobs:
           token: ${{ secrets.SANDSTONE_PAT }}
           repository: sandstone-mc/sandstone-libraries
           event-type: minecraft-update
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - uses: pnpm/action-setup@v2
         with:
           version: 8


### PR DESCRIPTION
Updates the CI workflow to use current GitHub-maintained action/runtime versions.

Changes:
- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/setup-node@v3` → `actions/setup-node@v4`
- `node-version: 16` → `node-version: 20`

Validation:
- YAML syntax verified
- Workflow semantics unchanged (only version bumps)
- Scope: `.github/workflows/mc-update.yml` only